### PR TITLE
Changed sort method to use localeCompare

### DIFF
--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -614,7 +614,7 @@ function editSubredditShortcut(ele, event) {
 		const currStr = inputEl.value;
 		// sort ASC
 		const ascArr = currStr.split('+');
-		ascArr.sort();
+		ascArr.sort((a, b) => a.localeCompare(b, undefined, {sensitivity: 'base'}));
 		const ascStr = ascArr.join('+');
 		// sort DESC
 		const descArr = ascArr;


### PR DESCRIPTION
Changed sorting method of the array to properly sort like123AaBbCc instead of 123abcABC using localeCompare.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: 
