### PR TITLE
Added pin icon to floater

### DIFF
--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -162,6 +162,28 @@ body.res-console-open {
 	}
 }
 
+#PHPrefs {
+	cursor: pointer;
+	margin-left: 4px;
+}
+
+.pinIcon {
+	text-decoration: none !important;
+	position: relative;
+
+	&::before,
+	&::after {
+		font: normal 14px/1 'Batch';
+		vertical-align: middle;
+	}
+
+	&::after {
+		content: '\1F4CC';
+		color: transparent;  
+		text-shadow: 0 0 0 #888;
+	}
+}
+
 #RESAnnouncementAlert {
 	display: inline-block;
 	vertical-align: bottom;

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Modules from '../core/modules';
+import * as Options from '../core/options';
 import {
 	Alert,
 	DAY,
@@ -21,6 +22,7 @@ import {
 	fromSecondsToTime,
 	string,
 } from '../utils';
+import * as Floater from './floater';
 import { _addHeaderId } from '../utils/dom';
 import { ajax, i18n } from '../environment';
 import { Expando } from './showImages/expando';
@@ -191,6 +193,8 @@ module.exclude = [
 	'd2x',
 ];
 
+let $PHPrefs;
+
 module.beforeLoad = () => {
 	if (module.options.commentsLinksNewTabs.value) {
 		watchForElements(['newComments', 'siteTable'], '.thing div.md a', commentsLinksNewTabs);
@@ -269,7 +273,38 @@ module.go = () => {
 		default:
 			break;
 	}
+	addPinHeaderCycler();
 };
+
+function addPinHeaderCycler() {
+	$PHPrefs = $('<div>', {
+		id: 'PHPrefs',
+		class: 'pinIcon',
+		title: 'Cycle pinHeader setting',
+		click: () => changePinHeaderSetting(),
+	});
+
+	Floater.addElement($PHPrefs);
+}
+
+function changePinHeaderSetting() {
+	if (module.options.pinHeader.value === 'none')
+	{
+		Options.set(module, 'pinHeader', 'sub');
+	} else if (module.options.pinHeader.value === 'sub')
+	{
+		Options.set(module, 'pinHeader', 'userbar');
+	} else if (module.options.pinHeader.value === 'userbar')
+	{
+		Options.set(module, 'pinHeader', 'subanduser');
+	} else if (module.options.pinHeader.value === 'subanduser')
+	{
+		Options.set(module, 'pinHeader', 'header');
+	} else if (module.options.pinHeader.value === 'header')
+	{
+		Options.set(module, 'pinHeader', 'none');
+	}
+}
 
 function commentsLinksNewTabs(link) {
 	const { baseURI, href } = link;


### PR DESCRIPTION
Added pin icon to floater menu bar that cycles through the available options. Effect is implemented on next page load.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: 
